### PR TITLE
Updated yaml and hosts config for additional sites

### DIFF
--- a/homestead.md
+++ b/homestead.md
@@ -210,7 +210,20 @@ To connect to your MySQL or Postgres database from your host machine's database 
 <a name="adding-additional-sites"></a>
 ### Adding Additional Sites
 
-Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installations as you wish on a single Homestead environment. To add an additional site, simply add the site to your `~/.homestead/Homestead.yaml` file and then run the `vagrant reload --provision` terminal command from your Homestead directory.
+Once your Homestead environment is provisioned and running, you may want to add additional Nginx sites for your Laravel applications. You can run as many Laravel installations as you wish on a single Homestead environment. To add an additional site, simply add the site to your `~/.homestead/Homestead.yaml` file: 
+
+    sites:
+        - map: homestead.app
+          to: /home/vagrant/Code/Laravel/public
+        - map: proj1.homestead.app
+          to: /home/vagrant/Code/proj1/public
+          
+You also need to add this to your `/etc/hosts` file:
+
+    192.168.10.10  homestead.app
+    192.168.10.10  proj1.homestead.app
+    
+and then run the `vagrant reload --provision` terminal command from your Homestead directory.
 
 <a name="configuring-cron-schedules"></a>
 ### Configuring Cron Schedules


### PR DESCRIPTION
In order to clarify the instructions, I added an example project to the `Homestead.yml` sites configuration example.  I illustrated this because in forums, people were updating the `folders` section instead of `sites`.  I also added the instructions for `/etc/hosts` because that detail was omitted from instructions.